### PR TITLE
fix: pods not found in lockfile with new syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,6 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     json (2.2.0)
-    minitest (5.11.3)
-    rake (12.3.2)
     rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
@@ -28,9 +26,7 @@ PLATFORMS
 DEPENDENCIES
   codecov
   colored2
-  minitest
-  rake
   rspec-mocks
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/cocoacache/core.rb
+++ b/lib/cocoacache/core.rb
@@ -36,7 +36,8 @@ module CocoaCache
 
     def get_pods()
       lockfile = YAML.load(File.read(@podfile_path))
-      pods = lockfile["SPEC REPOS"]["https://github.com/cocoapods/specs.git"]
+      spec_repos = lockfile["SPEC REPOS"].transform_keys {|key| key.downcase }
+      pods = spec_repos["https://github.com/cocoapods/specs.git"]
       return pods
     end
 

--- a/test/fixtures/Podfile.lock
+++ b/test/fixtures/Podfile.lock
@@ -1,5 +1,5 @@
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Alamofire
     - Kingfisher
     - Moya


### PR DESCRIPTION
I recently upgraded to v1.8.3 of cocoapods on my Catalina machine. When I did that and ran `pod install` on an iOS project, I noticed that cocoapods chnaged `https://github.com/cocoapods/specs.git` to `https://github.com/CocoaPods/Specs.git` in the `Podfile.lock` file. This caused CocoaCache to crash. 

Reproduce crash: change `test/fixtures/Podfile.lock` from `https://github.com/cocoapods/specs.git` to `https://github.com/CocoaPods/Specs.git` and run tests. That was the error I was receiving where Cocoacache could not find any pods. 

To fix this crash, I made cocoacache backwards and forwards compatible by simply ignoring the case of the `https://github.com/CocoaPods/Specs.git` key. 

Tests pass and after installing this change into my iOS project, it is working again. 